### PR TITLE
refactor : Xss를 적용 역할을 하는 XssStageEngine 추상화 생성

### DIFF
--- a/xss-core/src/main/java/org/stage/xss/core/config/XssStageConfigurer.java
+++ b/xss-core/src/main/java/org/stage/xss/core/config/XssStageConfigurer.java
@@ -4,7 +4,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.stage.xss.core.XssFilterAop;
+import org.stage.xss.core.engine.aop.XssFilterAopEngine;
 import org.stage.xss.core.spi.XssFilter;
 
 @Configuration
@@ -14,8 +14,8 @@ public class XssStageConfigurer{
     List<XssFilter> xssFilterList;
 
     @Bean
-    public XssFilterAop xssFilterAop(){
-        return new XssFilterAop(xssFilterList);
+    public XssFilterAopEngine xssFilterAop(){
+        return new XssFilterAopEngine(xssFilterList);
     }
 
 }

--- a/xss-core/src/main/java/org/stage/xss/core/engine/XssStageEngine.java
+++ b/xss-core/src/main/java/org/stage/xss/core/engine/XssStageEngine.java
@@ -1,0 +1,24 @@
+package org.stage.xss.core.engine;
+
+/**
+ * {@link org.stage.xss.core.spi.XssFilter} 구현체들을 파라미터에 적용하는 역할을 한다.
+ *
+ * @param <T> XssStageEngine 구현체의 메소드가 반환하는 타입이다.
+ * @param <P> XssStageEngine 구헨체가 받는 파라미터 값이다.
+ *
+ * @since 2.0
+ * @author devxb
+ */
+public interface XssStageEngine<T, P>{
+
+    /**
+     * 어떠한, Xss filtering이 필요한 파라미터를 받아 Xss safe한 상태를 반환한다.
+     *
+     * @param parameter 이 파라미터는 Xss filtering 대상인 어떤것이다.
+     * @return Xss safe한 상태를 반환한다.
+     *
+     * @since 2.0
+     */
+    T doFiltering(P parameter) throws Throwable;
+
+}

--- a/xss-core/src/main/java/org/stage/xss/core/engine/aop/XssFilterAopEngine.java
+++ b/xss-core/src/main/java/org/stage/xss/core/engine/aop/XssFilterAopEngine.java
@@ -1,4 +1,4 @@
-package org.stage.xss.core;
+package org.stage.xss.core.engine.aop;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
@@ -7,16 +7,17 @@ import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.stage.xss.core.engine.XssStageEngine;
 import org.stage.xss.core.exception.UnknownXssFilterName;
 import org.stage.xss.core.meta.Xss;
 import org.stage.xss.core.spi.XssFilter;
 
 @Aspect
-public class XssFilterAop{
+public class XssFilterAopEngine implements XssStageEngine<Object, ProceedingJoinPoint>{
 
     private final List<XssFilter> xssFilters;
 
-    public XssFilterAop(List<XssFilter> xssFilters){
+    public XssFilterAopEngine(List<XssFilter> xssFilters){
         this.xssFilters = xssFilters;
     }
 

--- a/xss-core/src/test/java/org/stage/xss/core/XssFilterAopReigsterTest.java
+++ b/xss-core/src/test/java/org/stage/xss/core/XssFilterAopReigsterTest.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.stage.xss.core.config.XssStageConfigurer;
+import org.stage.xss.core.engine.aop.XssFilterAopEngine;
 import org.stage.xss.core.exception.UnknownXssFilterName;
 import org.stage.xss.core.spi.TestXssFilter;
 
@@ -22,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class XssFilterAopReigsterTest{
 
     @Autowired
-    private XssFilterAop xssFilterAop;
+    private XssFilterAopEngine xssFilterAop;
 
     @Test
     @DisplayName("Xss Filtering 파라미터 한개 성공 테스트")


### PR DESCRIPTION
- Xss를 적용하는 역할을 하는 XssStageEngine 추상화를 생성했다.
- 기존의 XssFilteringAop를 XssFilteringAopEngine으로 이름을 바꾸고, 패키지도 engine.aop 아래로 이동시켰다.
- 이 추상화를 통해 2.0 버전에서는 AOP를 이용한 요청단의 Xss filtering과 더불어,
- Interceptor를 이용한 응답단의 Xss filtering도 처리하려고 한다.